### PR TITLE
Replaced PLUGINLIB_DECLARE_CLASS macro by PLUGINLIB_EXPORT_CLASS.

### DIFF
--- a/lslidar_c16/lslidar_c16_decoder/src/lslidar_c16_decoder_nodelet.cpp
+++ b/lslidar_c16/lslidar_c16_decoder/src/lslidar_c16_decoder_nodelet.cpp
@@ -31,5 +31,4 @@ void LslidarC16DecoderNodelet::onInit() {
 
 } // end namespace lslidar_c16_decoder
 
-PLUGINLIB_DECLARE_CLASS(lslidar_c16_decoder, LslidarC16Nodelet,
-    lslidar_c16_decoder::LslidarC16DecoderNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(lslidar_c16_decoder::LslidarC16DecoderNodelet, nodelet::Nodelet);

--- a/lslidar_c16/lslidar_c16_driver/src/lslidar_c16_driver_nodelet.cc
+++ b/lslidar_c16/lslidar_c16_driver/src/lslidar_c16_driver_nodelet.cc
@@ -77,5 +77,4 @@ void LslidarC16DriverNodelet::devicePoll()
 // Register this plugin with pluginlib.  Names must match nodelet_lslidar.xml.
 //
 // parameters are: package, class name, class type, base class type
-PLUGINLIB_DECLARE_CLASS(lslidar_c16_driver, LslidarC16DriverNodelet,
-                        lslidar_c16_driver::LslidarC16DriverNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(lslidar_c16_driver::LslidarC16DriverNodelet, nodelet::Nodelet);


### PR DESCRIPTION
PLUGINLIB_DECLARE_CLASS macro is no longer supported by pluginlib.