### PR TITLE
Fixed DISTANCE_RESOLUTION factor.

### DIFF
--- a/lslidar_c16/lslidar_c16_decoder/include/lslidar_c16_decoder/lslidar_c16_decoder.h
+++ b/lslidar_c16/lslidar_c16_decoder/include/lslidar_c16_decoder/lslidar_c16_decoder.h
@@ -53,7 +53,7 @@ static const int BLOCK_DATA_SIZE =
 // According to Bruce Hall DISTANCE_MAX is 65.0, but we noticed
 // valid packets with readings up to 130.0.
 static const double DISTANCE_MAX        = 130.0;        /**< meters */
-static const double DISTANCE_RESOLUTION = 0.01; /**< meters */
+static const double DISTANCE_RESOLUTION = 0.0025; /**< meters */
 static const double DISTANCE_MAX_UNITS  =
         (DISTANCE_MAX / DISTANCE_RESOLUTION + 1.0);
 


### PR DESCRIPTION
The point cloud scale is incorrect, everything is roughly 4 times bigger than in real life. After digging in the user manual, I found out that the unit of distance for distance measurements in the data packets is 0.25 cm, so I changed DISTANCE_RESOLUTION to 0.0025 meters.